### PR TITLE
Fix ICS end date and location bug

### DIFF
--- a/src/Domain/Events/Actions/EventGenerateIcsAction.php
+++ b/src/Domain/Events/Actions/EventGenerateIcsAction.php
@@ -10,10 +10,10 @@ class EventGenerateIcsAction
     public function execute(Event $event): string
     {
         $startDate        = Carbon::parse($event->start_date_time)->format('Ymd\THis');
-        $endDate          = Carbon::parse($event->start_date_time)->format('Ymd\THis');
+        $endDate          = Carbon::parse($event->end_date_time ?? $event->start_date_time)->format('Ymd\THis');
         $eventName        = addslashes($event->title);
         $eventDescription = addslashes($event->description);
-        $eventLocation    = addslashes($event->location);
+        $eventLocation    = addslashes($event->address?->address ?? '');
 
         // this format is necessary for the ics file to function
         return


### PR DESCRIPTION
## Summary
- correct end date field in EventGenerateIcsAction
- use address relation for event location in ICS file

## Testing
- `composer --version` *(fails: command not found)*
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_683fec695cfc8332914475641ce2fc3d